### PR TITLE
#21 chore: update base image version

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -11,19 +11,6 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     LANG="C.UTF-8" \
     PYTHONPATH=${APPLICATION_DIRECTORY}
 
-# Due to Nvidia's GPG repository key update, old key should be removed here.
-# NVIDIA blog: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
-# Reference: https://github.com/NVIDIA/nvidia-docker/issues/1631#issuecomment-1112828208
-# After the base image is updated, following block will be able to remove.
-# NOTE: If you want to chose not default base image, you might need to update DISTRO augment part.
-ARG DISTRO=ubuntu2004
-RUN rm /etc/apt/sources.list.d/cuda.list | true
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list | true
-RUN apt-key del 7fa2af80 | true
-RUN apt-key del F796ECB0 | true
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/${DISTRO}/x86_64/3bf863cc.pub | true
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/${DISTRO}/x86_64/7fa2af80.pub | true
-
 # Following is needed to install python 3.7
 RUN apt update && apt install --no-install-recommends -y software-properties-common 
 RUN add-apt-repository ppa:deadsnakes/ppa

--- a/environments/gpu/docker-compose.yaml
+++ b/environments/gpu/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
     build:
       args:
-        - BASE_IMAGE=nvidia/cuda:11.0-devel-ubuntu20.04
+        - BASE_IMAGE=nvidia/cuda:11.0.3-devel-ubuntu20.04
         - PYTHON_VERSION=3.8
       context: ../../
       dockerfile: environments/Dockerfile


### PR DESCRIPTION
## Issue URL

#21

## Change overview

- Update base image for GPU env from `nvidia/cuda:11.0-devel-ubuntu20.04` to `nvidia/cuda:11.0.3-devel-ubuntu20.04`.
- Remove workaround code added by #17.

## How to test

Check if `cd environments/gpu` and `sudo docker compose build --no-cache` works correctly.

## Note for reviewers

NA