### PR TITLE
Add watch to Makefile for using --watch option of node-sass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,8 @@ build-container:
 build:
 	docker build --tag ${CONTAINER-TAG} .
 	docker run --rm --volume $$(pwd)/src:/home/node/ascender/src --volume $$(pwd)/build:/home/node/ascender/build ${CONTAINER-TAG}
+
+.PHONY: watch
+watch:
+	docker build --tag ${CONTAINER-TAG} .
+	docker run --rm --volume $$(pwd)/src:/home/node/ascender/src --volume $$(pwd)/build:/home/node/ascender/build ${CONTAINER-TAG} --watch src/sass/main.scss --output-style compressed --output build


### PR DESCRIPTION
## Issue URL
None

## Change overview
Write SCSS and run `make build` every time is too boring. --watch option relieves us.

## How to test
Run `make watch` and update main.scss. main.css will be automatically generated.

## Note for reviewers
None