### PR TITLE
feat: use poetry 1.2 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ In Ascender, default value of both is `1000`. If UID or GID of your local PC is 
 
 ### Compatibility issue between PyTorch and Poetry
 
+NOTE: Now poetry 1.2 is used in Ascender. So this issue is expected to be solved.
+
 Currently, there is a compatibility issue between PyTorch and Poetry. This issue is being worked on by the Poetry community and is expected to be resolved in 1.2.0. (You can check pre-release of 1.2.0 from [here](https://github.com/python-poetry/poetry/releases/tag/1.2.0b3).) 
 
 We plan to incorporate Poetry 1.2.0 into Ascender immediately after its release. In the meantime, please consider using the workaround described in [this issue](https://github.com/python-poetry/poetry/issues/4231).

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ $ id -u $USER  # check UID
 $ id -g $USER  # check GID
 ```
 
-In Ascender, default value of both is `1000`. If UID or GID of your local PC is not `1000`, you need to modify the value of `UID` or `GID` inside of `docker-compose.yaml` to align your local PC (please edit their values from `1000`).
+In Ascender, default value of both is `1000`. If UID or GID of your local PC is not `1000`, you need to modify the value of `UID` or `GID` inside of `docker-compose.yaml` to align your local PC (please edit their values from `1000`). Or if environmental variables `HOST_UID` and `HOST_GID` is defined at host PC, Ascender uses these values.

--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -26,7 +26,10 @@ RUN apt update && apt install --no-install-recommends -y \
 # For detail, please check following link https://unix.stackexchange.com/questions/410579/change-the-python3-default-version-in-ubuntu
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
-    && pip3 install poetry
+    # `requests` needs to be upgraded to avoid RequestsDependencyWarning
+    # ref: https://stackoverflow.com/questions/56155627/requestsdependencywarning-urllib3-1-25-2-or-chardet-3-0-4-doesnt-match-a-s
+    && python3 -m pip install --upgrade pip 'setuptools==59.5.0' requests\
+    && python3 -m pip install --pre poetry
 
 # Add user. Without this, following process is executed as admin. 
 RUN groupadd -g ${GID} ${GROUP_NAME} \

--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -28,7 +28,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTH
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
     # `requests` needs to be upgraded to avoid RequestsDependencyWarning
     # ref: https://stackoverflow.com/questions/56155627/requestsdependencywarning-urllib3-1-25-2-or-chardet-3-0-4-doesnt-match-a-s
-    && python3 -m pip install --upgrade pip 'setuptools==59.5.0' requests\
+    && python3 -m pip install --upgrade pip setuptools requests \
     && python3 -m pip install --pre poetry
 
 # Add user. Without this, following process is executed as admin. 

--- a/environments/cpu/docker-compose.yaml
+++ b/environments/cpu/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
       args:
         - BASE_IMAGE=ubuntu:20.04
         - PYTHON_VERSION=3.8
-        - UID=1000
-        - GID=1000
+        - UID=${HOST_UID-1000}
+        - GID=${HOST_GID-1000}
       context: ../../
       dockerfile: environments/Dockerfile
     tty: true

--- a/environments/gpu/docker-compose.yaml
+++ b/environments/gpu/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       args:
         - BASE_IMAGE=nvidia/cuda:11.0.3-devel-ubuntu20.04
         - PYTHON_VERSION=3.8
-        - UID=1000
-        - GID=1000
+        - UID=${HOST_UID-1000}
+        - GID=${HOST_GID-1000}
       context: ../../
       dockerfile: environments/Dockerfile
     tty: true


### PR DESCRIPTION
## Issue URL

- https://github.com/cvpaperchallenge/Ascender/issues/53
- https://github.com/cvpaperchallenge/Ascender/issues/52

## Change overview

1.  use `poetry` 1.2 beta because major bugs are resolved now.
1.  load UID and GID from environmental variables.

## How to test

- About 1., please build and run containers, and run `poetry --version` inside of the container.
- About 2., please define environmental variables `HOST_UID` and `HOST_GID` at your host PC. Then build and run containers, and run `id challenger` to check UID and GID inside of the container.


## Note for reviewers

NA