### PR TITLE
60/chore/introduce poetry 1.2.0

### DIFF
--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -29,7 +29,7 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTH
     # `requests` needs to be upgraded to avoid RequestsDependencyWarning
     # ref: https://stackoverflow.com/questions/56155627/requestsdependencywarning-urllib3-1-25-2-or-chardet-3-0-4-doesnt-match-a-s
     && python3 -m pip install --upgrade pip setuptools requests \
-    && python3 -m pip install --pre poetry
+    && python3 -m pip install poetry
 
 # Add user. Without this, following process is executed as admin. 
 RUN groupadd -g ${GID} ${GROUP_NAME} \


### PR DESCRIPTION
## Issue URL

#60

## Change overview

- Remove the pre-release option from `pip install poetry` under the Dockerfile

## How to test

Run `docker compose up -d` as specified in Quick Start and confirm you can use any option described [here](https://python-poetry.org/blog/announcing-poetry-1.2.0/)

## Note for reviewers

close #60