### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Now, you are ready to start development with Ascender.
 ```bash
 # Stop container
 $ cd environments/gpu  # or `cd environments/cpu` 
-$ sudo dokcer compose stop
+$ sudo docker compose stop
 ```
 
 ## FAQ


### PR DESCRIPTION
`dokcer` -> `docker`