### PR TITLE
67/fix/add condition to target markdown files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ isort:
 
 .PHONY: mdformat
 mdformat:
-	poetry run mdformat .
+	poetry run mdformat *.md
 
 .PHONY: mdformat-check
 mdformat-check:
-	poetry run mdformat --check .
+	poetry run mdformat --check *.md
 
 .PHONY: mypy
 mypy:
@@ -50,9 +50,5 @@ lint:
 
 .PHONY: test-all
 test-all:
-	$(MAKE) black
-	$(MAKE) flake8
-	$(MAKE) isort
-	$(MAKE) mdformat
-	$(MAKE) mypy
+	$(MAKE) lint
 	$(MAKE) test


### PR DESCRIPTION
## Issue URL

#67

## Change overview

- Add target condition to `mdformat` and `mdformat-check` command. 

In the CI job created by #67 (https://github.com/cvpaperchallenge/Ascender/actions/runs/3165280310/jobs/5154186344), `mdformat-check` command try to check markdown files inside of `.cache` or `.venv`. This will be solved by specifying target condition.

- make `test-all` command `lint` + `test`. 

## How to test

Please check CI job result.

## Note for reviewers

NA