### PR TITLE
chore: use compose specification for GPU

### DIFF
--- a/environments/gpu/docker-compose.yaml
+++ b/environments/gpu/docker-compose.yaml
@@ -2,9 +2,13 @@ version: "3.8"
 
 services:
   core:
-    runtime: nvidia
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]
+              count: 1
     build:
       args:
         - BASE_IMAGE=nvidia/cuda:11.0.3-devel-ubuntu20.04


### PR DESCRIPTION
## Issue URL

NA

## Change overview

Use compose specification schema to specify GPU.

## How to test

```bash
% cd environments/gpu
% sudo docker compose up -d --force-recreate  # jump into container

$ nvidia-smi  # <- this should work 
$ exit

% sudo docker compose down
```

## Note for reviewers

NA

---

## Reference

- [docker docs (Turn on GPU access with Docker Compose)](https://docs.docker.com/compose/gpu-support/)
- [docker docs (Compose における GPU アクセスの有効化)](https://matsuand.github.io/docs.docker.jp.onthefly/compose/gpu-support/)
