### PR TITLE
#81/bug/fix cache problem

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,0 +1,66 @@
+name: cache
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  DOCKER_FILE_DIRECTORY: environments
+  DOCKER_COMPOSE_DIRECTORY: environments/ci
+  COMPOSE_DOCKER_CLI_BUILD: 1
+  DOCKER_BUILDKIT: 1
+  USE_CACHE: true
+
+jobs:
+  create-cache:
+    if: github.event.pull_request.merged == true
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: ${{ matrix.image }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+        python-version: ["3.8", "3.9"]
+        include:
+          - os: ubuntu
+            image: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version info
+        run: pwd && docker-compose --version && docker --version
+
+      - name: Set up Docker Buildx
+        if: env.USE_CACHE == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        if: env.USE_CACHE == 'true'
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache/${{ matrix.python-version }}
+          key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY), 'poetry.lock') }}
+
+      - name: Build docker image with cache using buildx
+        if: steps.build-cache.outputs.cache-hit != 'true' && env.USE_CACHE == 'true'
+        uses: docker/bake-action@v4
+        with:
+          files: docker-compose.yaml
+          workdir: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+          load: true
+          set: |
+            core.args.PYTHON_VERSION=${{ matrix.python-version }}
+            *.cache-from=type=local,src=/tmp/.buildx-cache/${{ matrix.python-version }}
+            *.cache-to=type=local,dest=/tmp/.buildx-cache-new/${{ matrix.python-version }}
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        if: steps.build-cache.outputs.cache-hit != 'true' && env.USE_CACHE == 'true'
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -32,10 +32,12 @@ jobs:
       - name: Check version info
         run: pwd && docker-compose --version && docker --version
 
+      # Provide a builder instance with docker buildx.
       - name: Set up Docker Buildx
         if: env.USE_CACHE == 'true'
         uses: docker/setup-buildx-action@v3
 
+      # Specify a cache directory for build cache, and reuse past build cache as long as there are no changes to the environment files.
       - name: Cache Docker layers
         if: env.USE_CACHE == 'true'
         id: build-cache
@@ -44,6 +46,7 @@ jobs:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
           key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY), 'poetry.lock') }}
 
+      # If build cache is not found, build the Docker image to create a new cache.
       - name: Build docker image with cache using buildx
         if: steps.build-cache.outputs.cache-hit != 'true' && env.USE_CACHE == 'true'
         uses: docker/bake-action@v4

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -28,10 +28,12 @@ jobs:
       - name: Check version info
         run: pwd && docker compose --version && docker --version
 
+      # Provide a builder instance with docker buildx.
       - name: Set up Docker Buildx
         if: env.USE_CACHE == 'true'
         uses: docker/setup-buildx-action@v3
 
+      # Specify a cache directory for build cache, and reuse past build cache as long as there are no changes to the environment files.
       - name: Cache Docker layers
         if: env.USE_CACHE == 'true'
         id: build-cache
@@ -40,6 +42,8 @@ jobs:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
           key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY), 'poetry.lock') }}
 
+      # If build cache is found, use it to build the Docker image.
+      # The build is carried out using the `bake` command from buildx, referencing the `docker-compose.yaml` for CI.
       - name: Build docker image with cache using buildx
         if: steps.build-cache.outputs.cache-hit == 'true' && env.USE_CACHE == 'true'
         uses: docker/bake-action@v4
@@ -51,6 +55,10 @@ jobs:
             core.args.PYTHON_VERSION=${{ matrix.python-version }}
             *.cache-from=type=local,src=/tmp/.buildx-cache/${{ matrix.python-version }}
 
+      # If build cache is not found, build the Docker image without cache.
+      # It also works with docker/bake-action, but the `bake` command creates `/tmp/.buildx-cache/${{ matrix.python-version }}` as specified in cache-from.
+      # Since it is a cache directory tracked by actions/cache, if the directory exists at the end of the workflow, unnecessary cache is created in the merge branch.
+      # We used the regular build command to avoid this problem.
       - name: Build docker image without cache using normal build
         if: steps.build-cache.outputs.cache-hit != 'true' || env.USE_CACHE != 'true'
         run: docker compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
-          key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY)) }}
+          key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY), 'poetry.lock') }}
 
       - name: Build docker image with cache using buildx
         if: steps.build-cache.outputs.cache-hit == 'true' && env.USE_CACHE == 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -79,12 +79,3 @@ jobs:
       - name: Run test code
         run: docker compose exec -T core make test
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
-
-        # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        if: env.USE_CACHE == 'true'
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -23,7 +23,7 @@ jobs:
             image: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check version info
         run: pwd && docker-compose --version && docker --version
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         if: env.USE_CACHE == 'true'
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
         if: env.USE_CACHE == 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -38,10 +38,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
-          key: buildx-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            buildx-${{ github.ref }}
-            buildx-
+          key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY)) }}
 
       - name: Build docker image with cache
         if: env.USE_CACHE == 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Set up Docker Buildx
         if: env.USE_CACHE == 'true'
-        id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -29,12 +29,12 @@ jobs:
         run: pwd && docker-compose --version && docker --version
 
       - name: Set up Docker Buildx
-        if: ${{ env.USE_CACHE == 'true' }}
+        if: env.USE_CACHE == 'true'
         id: buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        if: ${{ env.USE_CACHE == 'true' }}
+        if: env.USE_CACHE == 'true'
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
@@ -44,7 +44,7 @@ jobs:
             buildx-
 
       - name: Build docker image with cache
-        if: ${{ env.USE_CACHE == 'true' }}
+        if: env.USE_CACHE == 'true'
         run: |
           docker buildx bake \
           --builder="${{ steps.buildx.outputs.name }}" \
@@ -56,7 +56,7 @@ jobs:
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Build docker image
-        if: ${{ env.USE_CACHE != 'true' }}
+        if: env.USE_CACHE != 'true'
         run: docker-compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
@@ -88,7 +88,7 @@ jobs:
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
       - name: Move cache
-        if: ${{ env.USE_CACHE == 'true' }}
+        if: env.USE_CACHE == 'true'
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -32,8 +32,6 @@ jobs:
         if: ${{ env.USE_CACHE == 'true' }}
         id: buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: network=host
 
       - name: Cache Docker layers
         if: ${{ env.USE_CACHE == 'true' }}
@@ -45,32 +43,6 @@ jobs:
             buildx-${{ github.ref }}
             buildx-
 
-      - name: Cache Docker registry
-        if: ${{ env.USE_CACHE == 'true' }}
-        uses: actions/cache@v3
-        with:
-          path: /tmp/docker-registry/${{ matrix.python-version }}
-          key: docker-registry-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            docker-registry-${{ github.ref }}
-            docker-registry-
-
-      - name: Boot-up local Docker registry
-        if: ${{ env.USE_CACHE == 'true' }}
-        run: docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2
-
-      - name: Wait for Docker registry
-        if: ${{ env.USE_CACHE == 'true' }}
-        run: npx wait-on --httpTimeout 30000 tcp:5000
-
-      - name: Generate Docker image tag
-        run: |
-            SHA=${{ github.sha }}
-            TAG=$(TZ=UTC-9 date '+%Y%m')-${SHA:0:7}
-            echo "DOCKER_IMAGE_TAG_CI=$TAG" >> $GITHUB_ENV
-            echo TAG $TAG
-            echo "::set-output name=docker_image_tag_ci::$TAG"
-
       - name: Build docker image with cache
         if: ${{ env.USE_CACHE == 'true' }}
         run: |
@@ -79,18 +51,13 @@ jobs:
           --set="core.args.PYTHON_VERSION=${{ matrix.python-version }}" \
           --set="*.cache-from=type=local,src=/tmp/.buildx-cache/${{ matrix.python-version }}" \
           --set="*.cache-to=type=local,dest=/tmp/.buildx-cache-new/${{ matrix.python-version }}" \
-          --push \
+          --load
           -f docker-compose.yaml
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Build docker image
         if: ${{ env.USE_CACHE != 'true' }}
         run: docker-compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core
-        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
-
-      - name: Pull Docker image
-        if: ${{ env.USE_CACHE == 'true' }}
-        run: docker-compose pull
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Create and start docker container

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -34,13 +34,14 @@ jobs:
 
       - name: Cache Docker layers
         if: env.USE_CACHE == 'true'
+        id: build-cache
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
           key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY)) }}
 
       - name: Build docker image with cache using buildx
-        if: steps.cache-buildx-cache.outputs.cache-hit == 'true' && env.USE_CACHE == 'true'
+        if: steps.build-cache.outputs.cache-hit == 'true' && env.USE_CACHE == 'true'
         uses: docker/bake-action@v4
         with:
           files: docker-compose.yaml
@@ -51,7 +52,7 @@ jobs:
             *.cache-from=type=local,src=/tmp/.buildx-cache/${{ matrix.python-version }}
 
       - name: Build docker image without cache using normal build
-        if: steps.cache-buildx-cache.outputs.cache-hit != 'true' || env.USE_CACHE != 'true'
+        if: steps.build-cache.outputs.cache-hit != 'true' || env.USE_CACHE != 'true'
         run: docker compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -40,8 +40,8 @@ jobs:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
           key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY)) }}
 
-      - name: Build docker image with cache
-        if: env.USE_CACHE == 'true'
+      - name: Build docker image with cache using buildx
+        if: steps.cache-buildx-cache.outputs.cache-hit == 'true' && env.USE_CACHE == 'true'
         run: |
           docker buildx bake \
           --builder="${{ steps.buildx.outputs.name }}" \
@@ -52,8 +52,8 @@ jobs:
           -f docker-compose.yaml
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
-      - name: Build docker image
-        if: env.USE_CACHE != 'true'
+      - name: Build docker image without cache using normal build
+        if: steps.cache-buildx-cache.outputs.cache-hit != 'true' || env.USE_CACHE != 'true'
         run: docker compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check version info
-        run: pwd && docker-compose --version && docker --version
+        run: pwd && docker compose --version && docker --version
 
       - name: Set up Docker Buildx
         if: env.USE_CACHE == 'true'
@@ -57,11 +57,11 @@ jobs:
 
       - name: Build docker image
         if: env.USE_CACHE != 'true'
-        run: docker-compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core
+        run: docker compose build --parallel --build-arg PYTHON_VERSION=${{ matrix.python-version }} core
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Create and start docker container
-        run: docker-compose up --no-build -d
+        run: docker compose up --no-build -d
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       # pytest-cov export coverage data to a file
@@ -73,15 +73,15 @@ jobs:
       # In the built stage of Docker image, .venv dir is moved from working directory to prevent
       # overwrite by volume operation of Docker. Here, .venv is moved back to working directory.
       - name: Move .venv directory
-        run: docker-compose exec -T core mv ../.venv .
+        run: docker compose exec -T core mv ../.venv .
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Run lint
-        run: docker-compose exec -T core make lint
+        run: docker compose exec -T core make lint
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Run test code
-        run: docker-compose exec -T core make test
+        run: docker compose exec -T core make test
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
         # Temp fix

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -42,15 +42,14 @@ jobs:
 
       - name: Build docker image with cache using buildx
         if: steps.cache-buildx-cache.outputs.cache-hit == 'true' && env.USE_CACHE == 'true'
-        run: |
-          docker buildx bake \
-          --builder="${{ steps.buildx.outputs.name }}" \
-          --set="core.args.PYTHON_VERSION=${{ matrix.python-version }}" \
-          --set="*.cache-from=type=local,src=/tmp/.buildx-cache/${{ matrix.python-version }}" \
-          --set="*.cache-to=type=local,dest=/tmp/.buildx-cache-new/${{ matrix.python-version }}" \
-          --load
-          -f docker-compose.yaml
-        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+        uses: docker/bake-action@v4
+        with:
+          files: docker-compose.yaml
+          workdir: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+          load: true
+          set: |
+            core.args.PYTHON_VERSION=${{ matrix.python-version }}
+            *.cache-from=type=local,src=/tmp/.buildx-cache/${{ matrix.python-version }}
 
       - name: Build docker image without cache using normal build
         if: steps.cache-buildx-cache.outputs.cache-hit != 'true' || env.USE_CACHE != 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache Docker layers
         if: env.USE_CACHE == 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache/${{ matrix.python-version }}
           key: buildx-${{ hashFiles(format('{0}/Dockerfile', env.DOCKER_FILE_DIRECTORY), format('{0}/docker-compose.yaml', env.DOCKER_COMPOSE_DIRECTORY)) }}

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,4 +1,4 @@
-name: tests
+name: lint-and-test
 on: [pull_request]
 
 env:

--- a/environments/ci/docker-compose.yaml
+++ b/environments/ci/docker-compose.yaml
@@ -2,7 +2,6 @@ version: "3.8"
 
 services:
   core:
-    image: localhost:5000/core:${DOCKER_IMAGE_TAG_CI}
     build:
       args:
         - BASE_IMAGE=ubuntu:20.04

--- a/environments/ci/docker-compose.yaml
+++ b/environments/ci/docker-compose.yaml
@@ -2,6 +2,7 @@ version: "3.8"
 
 services:
   core:
+    image: ci
     build:
       args:
         - BASE_IMAGE=ubuntu:20.04

--- a/environments/cpu/docker-compose.yaml
+++ b/environments/cpu/docker-compose.yaml
@@ -18,4 +18,4 @@ services:
     volumes:
         - ../../:/home/challenger/${PROJECT_NAME_ENV}
     ports:
-        - 9700:8000
+        - 8000:8000


### PR DESCRIPTION
## Issue URL

close #81

## Change overview

- Split the existing workflow into two; one for running lint and test, the other for providing cache
- Remove the registry cache as we do not use built images multiple times in a single workflow
- Update all actions' version to the latest
- Use `docker/bake-action` instead of running the raw `docker buildx bake` command

## How to test

I conducted experiments on a forked repository, so please refer to it for verification. The experiment details and checklist for each item are as follows:

1. First, prepare the base branch `cache-BuildCache-only`.

---

### See [this pull request](https://github.com/YoshikiKubotani/AscenderTest/pull/28) for the result below.

2. Make an appropriate edit on the `test/create-first-cache` branch and observe the behavior of the `lint-and-test` workflow when a pull request is created against the `cache-BuildCache-only` branch.

    - [ ] In the `lint-and-test` workflow, the build is performed without using cache.
    - [ ] No cache is created.

3. Observe the behavior of the `cache` workflow when `test/create-first-cache` is merged into the `cache-BuildCache-only` branch.

    - [ ] In the `cache` workflow, the build process runs to cache the build cache.
    - [ ] Cache is created on the base branch.

---

### See [this pull request](https://github.com/YoshikiKubotani/AscenderTest/pull/29) for the result below.

4. Make an appropriate edit on the `test/use-existing-cache` branch and observe the behavior of the `lint-and-test` workflow when a pull request is created against the `cache-BuildCache-only` branch.

    - [ ] In the `lint-and-test` workflow, the build is performed using cache.
    - [ ] The workflow's execution time is reduced compared to 2.
    - [ ] No cache is created.

5. Observe the behavior of the `cache` workflow when `test/use-existing-cache` is merged into the `cache-BuildCache-only` branch.

    - [ ] In the `cache` workflow, almost all processing is skipped since build cache already exists.
    - [ ] No cache is created.

---

### See [this pull request](https://github.com/YoshikiKubotani/AscenderTest/pull/30) for the result below.

6. Edit `environments/ci/docker-compose.yaml` on the `test/create-another-cache` branch and observe the behavior of the `lint-and-test` workflow when a pull request is created against the `cache-BuildCache-only` branch.

    - [ ] In the` lint-and-test` workflow, the build is performed without using the existing cache due to changes in environment-related files.
    - [ ] No cache is created.

7. Observe the behavior of the `cache` workflow when `test/create-another-cache` is merged into the `cache-BuildCache-only` branch.

    - [ ] In the `cache` workflow, the build process runs to cache the new build cache.
    - [ ] Cache is created on the base branch.

## Note for reviewers

> [!Note]
> As [the cache will be removed in 7 days if not used](https://docs.github.com/ja/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy), please check the result as soon as possible.
