### PR TITLE
feat: support larger python version

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: ubuntu
             image: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ascender
 
 ![stable](https://img.shields.io/badge/stable-v0.1.3-blue)
-![python versions](https://img.shields.io/badge/python-3.8%20%7C%203.9-blue)
+![python versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)
 [![tests](https://github.com/cvpaperchallenge/Ascender/actions/workflows/lint-and-test.yaml/badge.svg)](https://github.com/cvpaperchallenge/Ascender/actions/workflows/lint-and-test.yaml)
 [![MIT License](https://img.shields.io/github/license/cvpaperchallenge/Ascender?color=green)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -15,32 +15,36 @@ ENV DEBIAN_FRONTEND="noninteractive" \
     LANG="C.UTF-8" \
     PYTHONPATH=${APPLICATION_DIRECTORY}
 
-# Following is needed to install python 3.7
-RUN apt update && apt install --no-install-recommends -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt update -y && apt install --no-install-recommends -y software-properties-common \
+    # Add deadsnakes PPA to install older Python versions
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y \
+    # Install specified Python
+    python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python3-pip python3-dev python-is-python3 \
+    build-essential openssl libssl-dev libffi-dev ca-certificates git curl make ssh openssh-client \
+    && update-ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt install --no-install-recommends -y \
-    git curl make ssh openssh-client \
-    python${PYTHON_VERSION} python3-pip python-is-python3
+# Swtich default python3 version
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
 
-# Following is needed to swtich default python3 version
-# For detail, please check following link https://unix.stackexchange.com/questions/410579/change-the-python3-default-version-in-ubuntu
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
-    && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
-    # `requests` needs to be upgraded to avoid RequestsDependencyWarning
-    # ref: https://stackoverflow.com/questions/56155627/requestsdependencywarning-urllib3-1-25-2-or-chardet-3-0-4-doesnt-match-a-s
-    && python3 -m pip install --upgrade pip setuptools requests \
+# Install pip for specified Python version
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
+
+RUN python3 -m pip install --upgrade pip setuptools requests wheel six urllib3 \
     && python3 -m pip install poetry
 
 # Add user. Without this, following process is executed as admin.
 RUN groupadd -g ${GID} ${GROUP_NAME} \
-    && useradd -ms /bin/sh -u ${UID} -g ${GID} ${USER_NAME}
+&& useradd -ms /bin/sh -u ${UID} -g ${GID} ${USER_NAME}
 
 USER ${USER_NAME}
 WORKDIR ${APPLICATION_DIRECTORY}
 
 # If ${RUN_POETRY_INSTALL_AT_BUILD_TIME} = "true", install Python package by Poetry and move .venv under ${HOME}.
 # This process is for CI (GitHub Actions). To prevent overwrite by volume of docker compose, .venv is moved under ${HOME}.
-COPY --chown=${UID}:${GID} pyproject.toml poetry.lock poetry.toml .
+COPY --chown=${UID}:${GID} pyproject.toml poetry.lock poetry.toml ./
 RUN test ${RUN_POETRY_INSTALL_AT_BUILD_TIME} = "true" && poetry install || echo "skip to run poetry install."
 RUN test ${RUN_POETRY_INSTALL_AT_BUILD_TIME} = "true" && mv ${APPLICATION_DIRECTORY}/.venv ${HOME}/.venv || echo "skip to move .venv."

--- a/environments/Dockerfile
+++ b/environments/Dockerfile
@@ -38,7 +38,7 @@ RUN python3 -m pip install --upgrade pip setuptools requests wheel six urllib3 \
 
 # Add user. Without this, following process is executed as admin.
 RUN groupadd -g ${GID} ${GROUP_NAME} \
-&& useradd -ms /bin/sh -u ${UID} -g ${GID} ${USER_NAME}
+    && useradd -ms /bin/sh -u ${UID} -g ${GID} ${USER_NAME}
 
 USER ${USER_NAME}
 WORKDIR ${APPLICATION_DIRECTORY}

--- a/environments/gpu/docker-compose.yaml
+++ b/environments/gpu/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     build:
       args:
         - BASE_IMAGE=nvidia/cuda:11.0.3-devel-ubuntu20.04
-        - PYTHON_VERSION=3.8
+        - PYTHON_VERSION=3.12
         - UID=${HOST_UID-1000}
         - GID=${HOST_GID-1000}
         - PROJECT_NAME=${PROJECT_NAME_ENV}


### PR DESCRIPTION
## Issue URL

#107 

## Change overview

- Update Dockerfile to support python `3.10`, `3.11`, `3.12`.
- Add python `3.10`, `3.11`, `3.12` to CI build matrix.
- Update python badge in `README.md`.
- Make default Python version to `3.12`.

## How to test

Please test following from Python `3.8` to `3.12` since build with GPU is not supported by CI now.

```bash
% cd environments/gpu
% sudo docker compose build --build-arg PYTHON_VERSION=<PLEASE_SPECIFY_PYTHON_VERSION>
% sudo docker compose exec core bash

# enter the container and check python version
$ python --version
```

On the other hand, build with CPU is tested by CI jobs.

## Note for reviewers

NA
